### PR TITLE
Escape some < > symbols and other minor things

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           readonly        attribute MediaStream      previewStream;
           [Throws] Promise<PhotoCapabilities> getPhotoCapabilities ();
           [Throws] Promise<void> setOptions (PhotoSettings? photoSettings);
-          [Throws] Promise<Blob>              takePhoto ();
+          [Throws] Promise<Blob>              takePhoto (PhotoSettings? photoSettings);
           [Throws] Promise<ImageBitmap>       grabFrame ();
         };
       </pre>
@@ -140,6 +140,31 @@
           <li>Gather data from the <code>MediaStreamTrack</code> into a <code>Blob</code> containing a single still image. The method of doing this will depend on the underlying device.  Devices may temporarily stop streaming data, reconfigure themselves with the appropriate photo settings, take the photo, and then resume streaming.  In this case, the stopping and restarting of streaming SHOULD cause <code>mute</code> and <code>unmute</code> events to fire on the Track in question.  </li>
           <li>Return a resolved promise with the Blob object.</li>
         </ol>
+
+
+        <table class="parameters">
+              <tbody>
+                <tr>
+                  <th>Parameter</th>
+                  <th>Type</th>
+                  <th>Nullable</th>
+                  <th>Optional</th>
+                  <th>Description</th>
+                </tr>
+                <tr>
+                  <td class="prmName">type</td>
+                  <td class="prmType"><code>PhotoSettings</code></td>
+                  <td class="prmNullTrue"><span role="img" aria-label=
+                  "True">&#10004;</span></td>
+                  <td class="prmOptFalse"><span role="img" aria-label=
+                  "False">&#10008;</span></td>
+                  <td class="prmDesc">
+                    The <code>PhotoSettings</code> dictionary to be applied.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+        </dd>
         </dd>
 
         <dt><dfn><code>grabFrame</code></dfn></dt>

--- a/index.html
+++ b/index.html
@@ -33,12 +33,12 @@
     </section>
 
     <section id='abstract'>
-      This document specifies the takePhoto() and grabFrame() methods, and corresponding camera settings for use with MediaStreamTracks as defined in Media Capture and Streams [[!GETUSERMEDIA]].
+      This document specifies the <code>takePhoto()</code> and <code>grabFrame()</code> methods, and corresponding camera settings for use with MediaStreamTracks (as defined in Media Capture and Streams [[!GETUSERMEDIA]]).
     </section>
 
     Introduction
     ------------
-    <p>The API defined in this document captures images from a valid MediaStreamTrack. The produced image can be in the form of a <code>Blob</code> (as defined in [[!FILE-API]]) or as an <code><a href="http://www.w3.org/TR/html51/webappapis.html#images">ImageBitmap</a></code> (as defined in [[!HTML51]])).  The source image is provided by the capture device that provides the MediaStreamTrack.  Moreover, picture-specific settings can be optionally provided as arguments that can be applied to the device for the capture.</p>
+    <p>The API defined in this document captures images from a valid MediaStreamTrack. The produced image can be in the form of a <code><a href="https://www.w3.org/TR/FileAPI/#blob">Blob</a></code> (as defined in [[!FILE-API]]) or as an <code><a href="http://www.w3.org/TR/html51/webappapis.html#images">ImageBitmap</a></code> (as defined in [[!HTML51]])).  The source image is provided by the capture device that provides the MediaStreamTrack.  Moreover, picture-specific settings can be optionally provided as arguments that can be applied to the device for the capture.</p>
 
     <section id="ImageCaptureAPI">
     <h2>Image Capture API</h2>
@@ -51,10 +51,10 @@
         interface ImageCapture {
           readonly        attribute MediaStreamTrack videoStreamTrack;
           readonly        attribute MediaStream      previewStream;
-          [Throws] Promise<PhotoCapabilities> getPhotoCapabilities ();
-          [Throws] Promise<void> setOptions (PhotoSettings? photoSettings);
-          [Throws] Promise<Blob>              takePhoto (PhotoSettings? photoSettings);
-          [Throws] Promise<ImageBitmap>       grabFrame ();
+          [Throws] Promise&ltPhotoCapabilities&gt getPhotoCapabilities ();
+          [Throws] Promise&ltvoid&gt setOptions (PhotoSettings? photoSettings);
+          [Throws] Promise&ltBlob&gt              takePhoto (PhotoSettings? photoSettings);
+          [Throws] Promise&ltImageBitmap&gt       grabFrame ();
         };
       </pre>
     </div>


### PR DESCRIPTION
Re. #32, I forgot escaping the < and > characters in the `ImageCapture` definition, this PR does it.

Also it adds some <code> and links in the first two sections.