### PR TITLE
Added a note on why imageHeight and imageWidth are enumerated

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,6 +256,9 @@
         <dt><dfn><code>focusMode</code></dfn> of type <span class="idlAttrType"><a>FocusMode</a></span></dt>
         <dd>This reflects the current focus mode setting.  Values are of type <code>FocusMode</code>.</dd>
       </dl>
+      <div class="note">
+      The supported resolutions are presented as segregated <code><a href="#dom-photocapabilities-imagewidth">imageWidth</a></code> and <code><a href="#dom-photocapabilities-imageheight">imageHeight</a></code> ranges to prevent increasing the fingerprinting surface and to allow the UA to make a best-effort decision with regards to actual hardware configuration.
+      </div>
     </section>
 
     <section id="photocapabilities-discussion" class="informative">


### PR DESCRIPTION
See the issue. Essentially, `imageWidth` and `imageHeight` are enumerated as two separate ranges ISO a lists of supported resolutions in order to prevent device fingerprinting and to allow the UA to make the best decision based on requests. Fixes #30.