### PR TITLE
Made MediaSettingsRange members signed (not unsigned).

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,20 +391,20 @@
     <div>
       <pre class="idl">
         interface MediaSettingsRange {
-            readonly        attribute unsigned long max;
-            readonly        attribute unsigned long min;
-            readonly        attribute unsigned long current;
+            readonly attribute long max;
+            readonly attribute long min;
+            readonly attribute long current;
         };
       </pre>
     </div>
     <section>
       <h2>Attributes</h2>
       <dl data-link-for="MediaSettingsRange" data-dfn-for="MediaSettingsRange" class="attributes">
-        <dt><dfn><code>max</code></dfn> of type <span class="idlAttrType"><a>unsigned long</a></span>, readonly</dt>
+        <dt><dfn><code>max</code></dfn> of type <span class="idlAttrType"><a>long</a></span>, readonly</dt>
         <dd>The maximum value of this setting</dd>
-        <dt><dfn><code>min</code></dfn> of type <span class="idlAttrType"><a>unsigned long</a></span>, readonly</dt>
+        <dt><dfn><code>min</code></dfn> of type <span class="idlAttrType"><a>long</a></span>, readonly</dt>
         <dd>The minimum value of this setting</dd>
-        <dt><dfn><code>current</code></dfn> of type <span class="idlAttrType"><a>unsigned long</a></span>, readonly</dt>
+        <dt><dfn><code>current</code></dfn> of type <span class="idlAttrType"><a>long</a></span>, readonly</dt>
         <dd>The current value of this setting</dd>
       </dl>
     </section>


### PR DESCRIPTION
I just noticed while implementing `exposureCompensation`, the values of `min` and `current` can be negative (and, potentially, so could `max`). This small patch corrects that.