### PR TITLE
FillLightMode 'on' should be called 'torch'

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@
             "auto",
             "off",
             "flash",
-            "on"
+            "torch"
         };
       </pre>
     </div>
@@ -419,7 +419,7 @@
         <dd>The source's fill light and/or flash will not be used.</dd>
         <dt><dfn><code>flash</code></dfn></dt>
         <dd>This value will always cause the flash to fire for the <code>takePhoto()</code> or <code>getFrame()</code> methods. </dd>
-        <dt><dfn><code>on</code></dfn></dt>
+        <dt><dfn><code>torch</code></dfn></dt>
         <dd>The source's fill light will be turned on (and remain on) while the source <code>MediaStreamTrack</code> is active</dd>
       </dl>
     </section>


### PR DESCRIPTION
Because when used in isolation, e.g. `setOptions({fillLightMode : 'on'});`,
"on" is not representative enough: it's confusing if it means "auto" or 
"always-on" or what.  setOptions({fillLightMode : 'torch'}); is more
self explanatory.