### PR TITLE
Removed ImageCaptureError in favour of DOMException

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,9 @@
        [Constructor(MediaStreamTrack track)]
         interface ImageCapture {
           readonly attribute MediaStreamTrack videoStreamTrack;
+          Promise&lt;Blob&gt;                 takePhoto ();
           Promise&lt;PhotoCapabilities&gt;    getPhotoCapabilities ();
           Promise&lt;void&gt;                 setOptions (PhotoSettings? photoSettings);
-          Promise&lt;Blob&gt;                 takePhoto ();
           Promise&lt;ImageBitmap&gt;          grabFrame ();
         };
       </pre>
@@ -77,16 +77,52 @@
     <section>
       <h2>Methods</h2>
       <dl data-link-for="ImageCapture" data-dfn-for="ImageCapture" class="methods">
-        <dt><dfn><code>getPhotoCapabilities</code></dfn></dt>
-        <dd>When the <code>getPhotoCapabilities()</code> method of an <code>ImageCapture</code> object is invoked, a new <i>Promise</i> is returned. If the UA is unable to execute the <code>getPhotoCapabilities()</code> method for any reason (for example, the <code>MediaStreamTrack</code> being ended asynchronously), then the UA MUST return a promise rejected with a newly created <a href="#idl-def-ImageCaptureError" class="idlType"><code>ImageCaptureError</code></a> with the appropriate <code>errorDescription</code> set. Otherwise it MUST queue a task, using the DOM manipulation task source, that runs the following steps:
+
+        <dt><dfn><code>takePhoto</code></dfn></dt>
+        <dd><code>takePhoto()</code> produces the result of a single photographic exposure using the video capture device sourcing the <a><code>videoStreamTrack</code></a>, applying any <a><code>PhotoSettings</code></a> previously configured, and returning an encoded image in the form of a <a><code>Blob</code></a> if successful. When this method is invoked:
         <ol>
+         <li>If the <code>readyState</code> of the <code>MediaStreamTrack</code> provided in the constructor is not `live`, throw a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"InvalidStateError"</code>. Otherwise:</li>
+
+         <li>Otherwise it MUST queue a task, using the DOM manipulation task source, that runs the following steps: </li>
+         <ol>
+          <li>Gather data from the <code>MediaStreamTrack</code> into a <code>Blob</code> containing a single still image. The method of doing this will depend on the underlying device.   Devices may temporarily stop streaming data, reconfigure themselves with the appropriate photo settings, take the photo, and then resume streaming.  In this case, the stopping and restarting of streaming SHOULD cause <code>mute</code> and <code>unmute</code> events to fire on the Track in question.  </li>
+
+          <li>If the UA is unable to execute the <code>takePhoto()</code> method for any reason (for example, upon invocation of multiple takePhoto() method calls in rapid succession), then the UA MUST return <a>a promise rejected with</a> a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"UnknownError"</code>.</li>
+
+          <li>Return a resolved promise with the Blob object.</li>
+         </ol>
+        </ol>
+        </dd>
+
+        <dt><dfn><code>getPhotoCapabilities</code></dfn></dt>
+        <dd>When  <code>getPhotoCapabilities()</code> is used to retrieve the ranges of available configuration options and their current setting values, if any. When this method is invoked:
+        <ol>
+         <li>If the <code>readyState</code> of the <code>MediaStreamTrack</code> provided in the constructor is not `live`, throw a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"InvalidStateError"</code>. </li>
+         <li>Otherwise it MUST queue a task, using the DOM manipulation task source, that runs the following steps:</li>
+         <ol>
           <li>Gather data from the <code>MediaStreamTrack</code> into a <a href="#idl-def-photocapabilities" class="idlType"><code>PhotoCapabilities</code></a> object containing the available capabilities of the device, including ranges where appropriate. The resolved <a href="#idl-def-photocapabilities" class="idlType"><code>PhotoCapabilities</code></a> will also include the current conditions in which the capabilities of the device are found. The method of doing this will depend on the underlying device. </li>
+          <li>If the UA is unable to execute the <code>getPhotoCapabilities()</code> method for any reason (for example, the <code>MediaStreamTrack</code> being ended asynchronously), then the UA MUST return <a>a promise rejected with</a> a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"OperationError"</code>.</li>
+
           <li>Return a resolved promise with the <a href="#idl-def-photocapabilities" class="idlType"><code>PhotoCapabilities</code></a> object.</li>
+         </ol>
         </ol>
         </dd>
 
         <dt><dfn><code>setOptions</code></dfn></dt>
-        <dd>When the <code>setOptions()</code> method of an <code>ImageCapture</code> object is invoked, then a valid <code>PhotoSettings</code> object MUST be passed in the method to the <code>ImageCapture</code> object.  In addition, a new <i>Promise</i> object is returned.  If the UA can successfully apply the settings, then the UA MUST return a resolved promise. If the UA cannot successfully apply the settings, then the UA MUST return a promise rejected with a newly created <a href="#idl-def-ImageCaptureError" class="idlType"><code>ImageCaptureError</code></a> whose <code>errorDescription</code> is set to OPTIONS_ERROR. If the UA can successfully apply the settings, the effect MAY be reflected, if visible at all, in <a href="#dom-imagecapture-videostreamtrack"><code>videoStreamTrack</code></a>.
+        <dd><code>setOptions()</code> is used to configure a number of settings affecting the image capture and/or the current video feed in <a><code>videoStreamTrack</code></a>. When this method is invoked:
+        <ol>
+         <li>If the <code>readyState</code> of the <code>MediaStreamTrack</code> provided in the constructor is not `live`, throw a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"InvalidStateError"</code>. </li>
+         <li>If an invalid <code>PhotoSettings</code> object is passed as argument, throw a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"SyntaxError"</code></li>
+         <li>Otherwise it MUST queue a task, using the DOM manipulation task source, that runs the following steps:</li>
+         <ol>
+           <li>Configure the underlying image capture device with the <code>settings</code> parameter.</li>
+           <li>If the UA cannot successfully apply the settings, then the UA MUST return <a>a promise rejected with</a> a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"OperationError"</code>. </li>
+           <li>If the UA can successfully apply the settings, then the UA MUST return a resolved promise.</li>
+           <div class="note">
+            If the UA can successfully apply the settings, the effect MAY be reflected, if visible at all, in <a><code>videoStreamTrack</code></a>.
+           </div>
+         </ol>
+        </ol>
         <table class="parameters">
               <tbody>
                 <tr>
@@ -97,7 +133,7 @@
                   <th>Description</th>
                 </tr>
                 <tr>
-                  <td class="prmName">type</td>
+                  <td class="prmName">settings</td>
                   <td class="prmType"><code>PhotoSettings</code></td>
                   <td class="prmNullTrue"><span role="img" aria-label=
                   "True">&#10004;</span></td>
@@ -111,47 +147,25 @@
             </table>
         </dd>
 
-        <dt><dfn><code>takePhoto</code></dfn></dt>
-        <dd>When the <code>takePhoto()</code> method of an <code>ImageCapture</code> object is invoked, a new <i>Promise</i> object is returned.
-        If the <code>readyState</code> of the <code>MediaStreamTrack</code> provided in the constructor is not "live", the UA MUST return a promise rejected with a newly created <a href="#idl-def-ImageCaptureError" class="idlType"><code>ImageCaptureError</code></a>  object whose <code>errorDescription</code> is set to INVALID_TRACK.  If the UA is unable to execute the <code>takePhoto()</code> method for any other reason (for example, upon invocation of multiple takePhoto() method calls in rapid succession), then the UA MUST return a promise rejected with a newly created <code>ImageCaptureError</code> object whose <code>errorDescription</code> is set to PHOTO_ERROR. Otherwise it MUST queue a task, using the DOM manipulation task source, that runs the following steps:
-        <ol>
-          <li>Let <var>photoSettings</var> be the method's first argument, if provided, or <code>undefined</code>.</li>
-
-          <li>Gather data from the <code>MediaStreamTrack</code> into a <code>Blob</code> containing a single still image. The method of doing this will depend on the underlying device.   Devices may temporarily stop streaming data, reconfigure themselves with the appropriate photo settings, take the photo, and then resume streaming.  In this case, the stopping and restarting of streaming SHOULD cause <code>mute</code> and <code>unmute</code> events to fire on the Track in question.  </li>
-
-          <li>Return a resolved promise with the Blob object.</li>
-        </ol>
-        </dd>
-
         <dt><dfn><code>grabFrame</code></dfn></dt>
-        <dd>When the <code>grabFrame()</code> method of an <code>ImageCapture</code> object is invoked, a new <i>Promise</i> object is returned. If the <code>readyState</code> of the <code>MediaStreamTrack</code> provided in the constructor is not "live", the UA MUST return a promise rejected with a newly created <code>ImageCaptureError</code> object whose <code>errorDescription</code> is set to INVALID_TRACK. If the UA is unable to execute the <code>grabFrame()</code> method for any other reason, then the UA MUST return a promise rejected with a newly created <a href="#idl-def-ImageCaptureError" class="idlType"><code>ImageCaptureError</code></a>  object whose <code>errorDescription</code> is set to FRAME_ERROR.    Otherwise it MUST queue a task, using the DOM manipulation task source, that runs the following steps:
+        <dd><code>grabFrame()</code> takes a snapshot of the live video being held in the <a><code>videoStreamTrack</code></a>, returning an <a><code>ImageBitmap</code></a> if successful. When this method is invoked:
         <ol>
-          <li>Gathers data from the <code>MediaStreamTrack</code> into an <code><a href="https://www.w3.org/TR/html51/webappapis.html#webappapis-images">ImageBitmap</a></code> object (as defined in [[!HTML51]]). The <code>width</code> and <code>height</code> of the <code><a href="https://www.w3.org/TR/html51/webappapis.html#webappapis-images">ImageBitmap</a></code> object are derived from the constraints of the <code>MediaStreamTrack</code>. </li>
+         <li>If the <code>readyState</code> of the <code>MediaStreamTrack</code> provided in the constructor is not `live`, throw a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"InvalidStateError"</code>. Otherwise:</li>
+
+         <li>Otherwise it MUST queue a task, using the DOM manipulation task source, that runs the following steps: </li>
+         <ol>
+          <li>Gather data from the <code>MediaStreamTrack</code> into an <code><a href="https://www.w3.org/TR/html51/webappapis.html#webappapis-images">ImageBitmap</a></code> object (as defined in [[!HTML51]]). The <code>width</code> and <code>height</code> of the <code><a href="https://www.w3.org/TR/html51/webappapis.html#webappapis-images">ImageBitmap</a></code> object are derived from the constraints of the <code>MediaStreamTrack</code>. </li>
+
           <li>Returns a resolved promise with a newly created <code><a href="https://www.w3.org/TR/html51/webappapis.html#webappapis-images">ImageBitmap</a></code> object. (Note: <code>grabFrame()</code> returns data only once upon being invoked).</li>
+
+          <li>If the UA is unable to execute the <code>takePhoto()</code> method for any reason (for example, upon invocation of multiple takePhoto() method calls in rapid succession), then the UA MUST return <a>a promise rejected with</a> a new <code>DOMException</code> ([[!WebIDL]]) whose name is <code>"UnknownError"</code>.</li>
+
+         </ol>
         </ol>
         </dd>
       </dl>
     </section>
 
-    </section>
-
-    <section id="ImageCaptureError">
-    <h2><code>ImageCaptureError</code></h2>
-    <div>
-      <pre class="idl">
-        [NoInterfaceObject] interface ImageCaptureError {
-          readonly attribute DOMString? errorDescription;
-        };
-      </pre>
-    </div>
-
-    <section>
-      <h2>Attributes</h2>
-      <dl data-link-for="ImageCaptureError" data-dfn-for="ImageCaptureError" class="attributes">
-        <dt><dfn><code>errorDescription</code></dfn> of type <span class="idlAttrType"><a>DOMString?</a></span>, readonly</dt>
-        <dd>The <code>errorDescription</code> attribute returns the appropriate DOMString for the error description.  Acceptable values are FRAME_ERROR, OPTIONS_ERROR, PHOTO_ERROR, INVALID_TRACK, and ERROR_UNKNOWN.</dd>
-      </dl>
-    </section>
     </section>
 
     <section id="PhotoCapabilities">


### PR DESCRIPTION
... and also rewritten the 4 method's descriptions to be more Promise-based and homogeneous.

This is a quite a bit of a change, but I believe we can just take this chance to revamp up these few lines.  To ease reviewing, [1] contains a rendering of this PR.


[1] https://rawgit.com/Miguelao/mediacapture-image/prO__use_DOMException/index.html