### PR TITLE
MediaSettingsRange.step shows up in M56

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -37,7 +37,7 @@ setOptions()              | ✓       | 55       | 55  | 55    |         |
 └ sharpness               | ✓       | 55       |     | 55    |         |
 └ whiteBalanceMode        | ✓       |          |     |       |         |
 └ zoom                    | ✓       | 55       |     | 55    |         |
-MediaSettingsRange.step   | 55      | 55       |     | 55    |         |
+MediaSettingsRange.step   | 56      | 56       |     | 56    |         |
 
 Note: Values of `PhotoCapabilities`/`Settings` depend on the actual capture device configurability (e.g. if the device doesn't support `zoom`, `zoom.min` and `zoom.max` will both be 0) .
 


### PR DESCRIPTION
If I'm not mistaken, `MediaSettingsRange.step` was introduced in https://chromium.googlesource.com/chromium/src.git/+/8f17f7e85f0c37a5d6549ea252baa15b9653a974
According to https://chromium.googlesource.com/chromium/src/+/8f17f7e85f0c37a5d6549ea252baa15b9653a974/chrome/VERSION, Chrome version is:
```
MAJOR=56
MINOR=0
BUILD=2891
PATCH=0
