### PR TITLE
Made Point2D general and moved its semantics to the pointsOfInterest entry (#125)

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,7 +333,11 @@
         <dt><dfn><code>focusMode</code></dfn> of type <span class="idlAttrType"><a>MeteringMode</a></span></dt>
         <dd>This reflects the desired focus mode setting.  Acceptable values are of type <span class="idlAttrType"><a>MeteringMode</a></span>.</dd>
         <dt><dfn><code>pointsOfInterest</code></dfn> of type <span class="idlAttrType">sequence&lt;<a>Point2D</a>&gt;</span></dt>
-        <dd>A <code>sequence</code> of <a>Point2D</a>s to be used as metering area centers for other settings, e.g. Focus, Exposure and Auto White Balance.</dd>
+        <dd>A <code>sequence</code> of <a>Point2D</a>s to be used as metering area centers for other settings, e.g. Focus, Exposure and Auto White Balance.
+        <div class="note">
+        A <a>Point2D</a> Point of Interest is interpreted to represent a pixel position in a normalized square space (`{x,y} &isin; [0.0, 1.0]`). The origin of coordinates `{x,y} = {0.0, 0.0}` represents the upper leftmost corner whereas the `{x,y} = {1.0, 1.0}` represents the lower rightmost corner: the <a href="#dom-point2d-x"><code>x</code></a> coordinate (columns) increases rightwards and the <a href="#dom-point2d-y"><code>y</code></a> coordinate (rows) increases downwards. Values beyond the mentioned limits will be clamped to the closest allowed value.
+        </div>
+        </dd>
         <dt><dfn><code>brightness</code></dfn> of type <span class="idlAttrType"><a>double</a></span></dt>
         <dd>This reflects the desired <a href="#dfn-brightness">brightness</a> setting of the camera.</dd>
         <dt><dfn><code>contrast</code></dfn> of type <span class="idlAttrType"><a>double</a></span></dt>
@@ -443,21 +447,22 @@
 
 
     <section id="Point2D">
-    <p>A <code>Point2D</code> represents a location in a normalized square space with values in `[0.0, 1.0]`. The origin of coordinates `(0.0, 0.0)` represents the upper leftmost corner, with the `y` coordinate pointing downwards.
+    <p>A <code>Point2D</code> represents a location in a two dimensional space.
     <h2><code>Point2D</code></h2>
     <div> <pre class="idl">
       dictionary Point2D {
-        float x = 0.0;
-        float y = 0.0;
+        double x = 0.0;
+        double y = 0.0;
       };
     </pre></div>
     <section>
       <h2>Attributes</h2>
       <dl data-link-for="Point2D" data-dfn-for="Point2D" class="attributes">
-        <dt><dfn><code>x</code></dfn> of type <span class="idlAttrType"><a>float</a></span></dt>
-        <dd>Value of the normalized horizontal (abscissa) coordinate in the range `[0.0, 1.0]`. Increasing `x` values correspond to increasing column indexes of an image.</dd>
-        <dt><dfn><code>y</code></dfn> of type <span class="idlAttrType"><a>float</a></span></dt>
-        <dd>Value of the normalized vertical (ordinate) coordinate in the range `[0.0, 1.0]`. Increasing `y` values correspond to increasing row indexes of an image.</dd>
+        <dt><dfn><code>x</code></dfn> of type <span class="idlAttrType"><a>double</a></span></dt>
+        <dd>Value of the horizontal (abscissa) coordinate.</dd>
+
+        <dt><dfn><code>y</code></dfn> of type <span class="idlAttrType"><a>double</a></span></dt>
+        <dd>Value of the vertical (ordinate) coordinate.</dd>
       </dl>
     </section>
     </section>


### PR DESCRIPTION
Made `Point2D` general and moved its semantics to the `pointsOfInterest` entry.

Also changed the `Point2D` attributes from `float` to `double`.