### PR TITLE
Added UVC informative ref and further defined the associated fields (#128)

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,13 +222,13 @@
         <dd>This reflects the current focus mode setting.</dd>
 
         <dt><dfn><code>brightness</code></dfn> of type <span class="idlAttrType"><a>MediaSettingsRange</a></span></dt>
-        <dd>This reflects the current <a href="#dfn-brightness">brightness</a> setting of the camera and permitted range. Values are numeric.</dd>
+        <dd>This reflects the current <a href="#dfn-brightness">brightness</a> setting of the camera and permitted range. Values are numeric. Increasing values indicate increasing brightness.</dd>
         <dt><dfn><code>contrast</code></dfn> of type <span class="idlAttrType"><a>MediaSettingsRange</a></span></dt>
-        <dd>This reflects the current <a href="#dfn-contrast">contrast</a> setting of the camera and permitted range. Values are numeric.</dd>
+        <dd>This reflects the current <a href="#dfn-contrast">contrast</a> setting of the camera and permitted range. Values are numeric.  Increasing values indicate increasing contrast.</dd>
         <dt><dfn><code>saturation</code></dfn> of type <span class="idlAttrType"><a>MediaSettingsRange</a></span></dt>
-        <dd>This reflects the current <a href="#dfn-saturation">saturation</a> setting of the camera and permitted range. Values are numeric.</dd>
+        <dd>This reflects the current <a href="#dfn-saturation">saturation</a> setting of the camera and permitted range. Values are numeric. Increasing values indicate increasing saturation.</dd>
         <dt><dfn><code>sharpness</code></dfn> of type <span class="idlAttrType"><a>MediaSettingsRange</a></span></dt>
-        <dd>This reflects the current <a href="#dfn-sharpness">sharpness</a> setting of the camera and permitted range. Values are numeric.</dd>
+        <dd>This reflects the current <a href="#dfn-sharpness">sharpness</a> setting of the camera and permitted range. Values are numeric. Increasing values indicate increasing sharpness, and the minimum value always implies no sharpness enhancement or processing.</dd>
         <dt><dfn><code>imageHeight</code></dfn> of type <span class="idlAttrType"><a>MediaSettingsRange</a></span></dt>
         <dd>This reflects the image height range supported by the UA and the current height setting.</dd>
         <dt><dfn><code>imageWidth</code></dfn> of type <span class="idlAttrType"><a>MediaSettingsRange</a></span></dt>
@@ -245,7 +245,7 @@
 
     <section id="photocapabilities-discussion" class="informative">
       <h2>Discussion</h2>
-        <p>The <code>PhotoCapabilities</code> interface provides the photo-specific settings options and current settings values.  The following definitions are assumed for individual settings and are provided for information purposes:</p>
+        <p>The <code>PhotoCapabilities</code> interface provides the photo-specific settings and their current values.  Many of these fields mirror hardware capabilities that are hard to define since can be implemented in a number of ways.  Moreover, hardware manufacturers tend to publish vague definitions to protect their intellectual property.  The following definitions are assumed for individual settings and are provided for information purposes:</p>
         <ol>
         <li><i><dfn>White balance mode</dfn></i> is a setting that cameras use to adjust for different color temperatures.  <dfn>Color temperature</dfn> is the temperature of background light (usually measured in Kelvin).  This setting can usually be automatically and continuously determined by the implementation, but it's also common to offer a `manual` mode in which the estimated temperature of the scene illumination is hinted to the implementation.  Typical temperature ranges for popular modes are provided below:
         <table class="simple">
@@ -278,14 +278,14 @@
 
         <li><i><dfn>Sharpness</dfn></i> is a numeric camera setting that controls the intensity of edges in a scene.  Higher sharpness settings result in higher contrast along the edges, while lower settings result in less contrast and blurrier edges (i.e. soft focus). The implementation is platform dependent, but it can be understood as the linear combination of an edge detection operation applied on the original image and the original image itself; the relative weights being cotrolled by this `sharpness`.</li>
 
+        <div class="note">
+        <a>Brightness</a>, <a>contrast</a>, <a>saturation</a> and <a>sharpness</a> are specified in [[UVC]].
+        </div>
+
         <li><i>Zoom</i> is a numeric camera setting that controls the focal length of the lens.  The setting usually represents a ratio, e.g. 4 is a zoom ratio of 4:1.  The minimum value is usually 1, to represent a 1:1 ratio (i.e. no zoom).</li>
 
         <li><i>Fill light mode</i> describes the flash setting of the capture device (e.g. `auto`, `off`, `on`). </li>
         </ol>
-
-      <div class="note">
-      Many of these fields mirror hardware capabilities that can be implemented in a number of ways, preventing further definition. Moreover, hardware manufacturers tend to publish vague definitions to protect their intellectual property.
-      </div>
 
     </section>
     </section>

--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ var respecConfig = {
         href: "http://www.iso.org/iso/catalogue_detail.htm?csnumber=37777",
         date: "15 April 2006",
         publisher: "ISO/IEC",
+      },
+      "UVC": {
+        title: "USB Device Class Definition for Video Devices",
+        href: "http://www.usb.org/developers/docs/devclass_docs/",
+        date: "9 August 2012",
+        publisher: "USB Implementers Forum Inc.",
       }
     }
 };


### PR DESCRIPTION

Correction to what I wrote in #128: 
> On the plus side, controls provide max,min, and default values, which would answer part of your question -- but now e.g. what would negative values do.

On second readings the UVC specifies the orientation of the scale by indicating that `increasing values indicate increasing {brightness, contrast, saturation, sharpness}`; I'm reflecting that in the document now.

Again, note that the individual `photoCapabilities` discussion is non-normative.