### PR TITLE
Add pan and tilt constraints

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -51,9 +51,11 @@ Feature/Platform          | Android                               | Linux/Chrome
 └ focusDistance           |   ([732807](https://crbug.com/732807))|                |                                         |     |
 └ focusMode               | ✓                                     | ✓              | 60 ([657128](https://crbug.com/657128)) |     |
 └ iso                     | ✓                                     |                |                                         |     |
+└ pan                     |                                       |                |                                         |     |
 └ pointsOfInterest        | ✓                                     |                |                                         |     |
 └ saturation              |                                       | ✓              | 60 ([657128](https://crbug.com/657128)) |     |
 └ sharpness               |                                       | ✓              | 60 ([657128](https://crbug.com/657128)) |     |
+└ tilt                    |                                       |                |                                         |     |
 └ whiteBalanceMode        | ✓                                     | ✓              | 60 ([657128](https://crbug.com/657128)) |     |
 └ zoom                    | ✓                                     | ✓              | 60 ([657128](https://crbug.com/657128)) |     |
 

--- a/index.bs
+++ b/index.bs
@@ -356,9 +356,11 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
 
     boolean brightness = true;
     boolean contrast = true;
+    boolean pan = true;
     boolean saturation = true;
     boolean sharpness = true;
     boolean focusDistance = true;
+    boolean tilt = true;
     boolean zoom = true;
     boolean torch = true;
   };
@@ -394,6 +396,9 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dt><dfn dict-member for="MediaTrackSupportedConstraints"><code>contrast</code></dfn></dt>
   <dd>Whether <a>contrast</a> constraining is recognized.</dd>
 
+  <dt><dfn dict-member for="MediaTrackSupportedConstraints"><code>pan</code></dfn></dt>
+  <dd>Whether <a>pan</a> constraining is recognized.</dd>
+
   <dt><dfn dict-member for="MediaTrackSupportedConstraints"><code>saturation</code></dfn></dt>
   <dd>Whether <a>saturation</a> constraining is recognized.</dd>
 
@@ -402,6 +407,9 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
 
   <dt><dfn dict-member for="MediaTrackSupportedConstraints"><code>focusDistance</code></dfn></dt>
   <dd>Whether <a>focus distance</a> constraining is recognized.</dd>
+
+  <dt><dfn dict-member for="MediaTrackSupportedConstraints"><code>tilt</code></dfn></dt>
+  <dd>Whether <a>tilt</a> constraining is recognized.</dd>
 
   <dt><dfn dict-member for="MediaTrackSupportedConstraints"><code>zoom</code></dfn></dt>
   <dd>Whether configuration of the <a>zoom</a> level is recognized.</dd>
@@ -430,6 +438,8 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
     MediaSettingsRange   sharpness;
 
     MediaSettingsRange   focusDistance;
+    MediaSettingsRange   pan;
+    MediaSettingsRange   tilt;
     MediaSettingsRange   zoom;
 
     boolean              torch;
@@ -463,6 +473,9 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>contrast</code></dfn></dt>
   <dd>This reflects the supported range of <a>contrast</a>. Values are numeric.  Increasing values indicate increasing contrast.</dd>
 
+  <dt><dfn dict-member for="MediaTrackCapabilities"><code>pan</code></dfn></dt>
+  <dd>This reflects the <a>pan</a> value range supported by the UA.</dd>
+
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>saturation</code></dfn></dt>
   <dd>This reflects the permitted range of <a>saturation</a> setting. Values are numeric. Increasing values indicate increasing saturation.</dd>
 
@@ -471,6 +484,9 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>focusDistance</code></dfn></dt>
   <dd>This reflects the <a>focus distance</a> value range supported by the UA.</dd>
+
+  <dt><dfn dict-member for="MediaTrackCapabilities"><code>tilt</code></dfn></dt>
+  <dd>This reflects the <a>tilt</a> value range supported by the UA.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>zoom</code></dfn></dt>
   <dd>This reflects the <a>zoom</a> value range supported by the UA.</dd>
@@ -504,6 +520,8 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
     ConstrainDouble    sharpness;
 
     ConstrainDouble    focusDistance;
+    ConstrainDouble    pan;
+    ConstrainDouble    tilt;
     ConstrainDouble    zoom;
 
     ConstrainBoolean   torch;
@@ -540,6 +558,9 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>contrast</code></dfn></dt>
   <dd>See <a>contrast</a> constrainable property.</dd>
 
+  <dt><dfn dict-member for="MediaTrackConstraintSet"><code>pan</code></dfn></dt>
+  <dd>See <a>pan</a> constrainable property.</dd>
+
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>saturation</code></dfn></dt>
   <dd>See <a>saturation</a> constrainable property.</dd>
 
@@ -548,6 +569,9 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>focusDistance</code></dfn></dt>
   <dd>See <a>focus distance</a> constrainable property.</dd>
+
+  <dt><dfn dict-member for="MediaTrackConstraintSet"><code>tilt</code></dfn></dt>
+  <dd>See <a>tilt</a> constrainable property.</dd>
 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>zoom</code></dfn></dt>
   <dd>See <a>zoom</a> constrainable property.</dd>
@@ -577,6 +601,8 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
     double            sharpness;
 
     double            focusDistance;
+    double            pan;
+    double            tilt;
     double            zoom;
 
     boolean           torch;
@@ -613,6 +639,9 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
   <dt><dfn dict-member for="MediaTrackSettings"><code>contrast</code></dfn></dt>
   <dd>This reflects the current <a>contrast</a> setting of the camera.</dd>
 
+  <dt><dfn dict-member for="MediaTrackSettings"><code>pan</code></dfn></dt>
+  <dd>This reflects the current <a>pan</a> setting of the camera.</dd>
+
   <dt><dfn dict-member for="MediaTrackSettings"><code>saturation</code></dfn></dt>
   <dd>This reflects the current <a>saturation</a> setting of the camera.</dd>
 
@@ -621,6 +650,9 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
   <dt><dfn dict-member for="MediaTrackSettings"><code>focusDistance</code></dfn></dt>
   <dd>This reflects the current <a>focus distance</a> setting of the camera.</dd>
+
+  <dt><dfn dict-member for="MediaTrackSettings"><code>tilt</code></dfn></dt>
+  <dd>This reflects the current <a>tilt</a> setting of the camera.</dd>
 
   <dt><dfn dict-member for="MediaTrackSettings"><code>zoom</code></dfn></dt>
   <dd>This reflects the current <a>zoom</a> setting of the camera.</dd>
@@ -707,6 +739,14 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
     </li>
 
     <li><dfn>Focus distance</dfn> is a numeric camera setting that controls the focus distance of the lens.  The setting usually represents distance in meters to the optimal focus distance.</li>
+
+    <li><dfn>Pan</dfn> is a numeric camera setting that controls the pan of the camera.  The setting represents pan in arc seconds, which are 1/3600th of a degree.  Values are in the range from –180*3600 arc seconds to +180*3600 arc seconds.  Positive values pan the camera clockwise as viewed from above, and negative values pan the camera counter clockwise as viewed from above.</li>
+
+    <li><dfn>Tilt</dfn> is a numeric camera setting that controls the tilt of the camera.  The setting represents tilt in arc seconds, which are 1/3600th of a degree.  Values are in the range from –180*3600 arc seconds to +180*3600 arc seconds.  Positive values tilt the camera upward when viewed from the front, and negative values tilt the camera downward as viewed from the front.
+
+    <div class="note">
+      There is no defined order when applying <a>pan</a> and <a>tilt</a>, the UA is allowed to apply them in any order.  In practice this should not matter since these values are absolute, so order will not affect the final position.  However, if applying pan and tilt is slow enough, the order in which they are applied may be visually noticeable.
+    </div></li>
 
     <li><dfn>Zoom</dfn> is a numeric camera setting that controls the focal length of the lens.  The setting usually represents a ratio, e.g. 4 is a zoom ratio of 4:1.  The minimum value is usually 1, to represent a 1:1 ratio (i.e. no zoom).</li>
 


### PR DESCRIPTION
As promised in issue #177.

Only real thing I can think of worth debating is whether to have the setting value be degrees, or arc seconds. They're trivial to convert between, and in UVC it is defined as arc seconds, as well as in more of the Windows APIs.

Degrees would be more intuitive for users, but since the underlying API will be returning the `max`/`min`/`step` in arc seconds, the `MediaSettingsRange` may look quite odd if you convert it to degrees, like from `-38.23` to `38.23` with steps of `0.453`. That could also lead to rounding problems in the conversion if the `step` in arc seconds is say 1000, that would be 0.277778 degrees, which is icky to deal with. As long as the camera "snaps" to the nearest valid step the rounding problems matter less, although it's never a great idea to have the value returned be different than the one you just set if the set succeeds. It's unintuitive and could lead to user code failing. Since either setting could be mechanical it may not apply immediately, and any end user code which keeps checking to see if it has changed to the correct value might fail or infinite loop if they set `21.234` degrees and that snaps to `21.2335` or something similar, since a simple `==` check would not be true.

@yellowdoge, I'm fairly confident these aren't available in the Android API. Would it make sense to use an `✕` in the implementation status to indicate that feature will never be available? The blank space would indicate that the feature is just not implemented yet, but could be in the future, versus `✕` means it will never be available.