### PR TITLE
Remove trailing commas from enums

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -292,7 +292,7 @@ interface ImageCapture {
   enum RedEyeReduction {
     "never",
     "always",
-    "controllable",
+    "controllable"
   };
 </pre>
 
@@ -317,7 +317,7 @@ interface ImageCapture {
   enum FillLightMode {
     "auto",
     "off",
-    "flash",
+    "flash"
   };
 </pre>
 


### PR DESCRIPTION
This is not allowed per the Web IDL syntax:
https://heycam.github.io/webidl/#idl-enums