### PR TITLE
Change mailing-list to public-webrtc

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12,7 +12,7 @@ Editor: Miguel Casas-Sanchez, w3cid 82825, Google Inc., mcasas@google.com
 Abstract: This document specifies methods and camera settings to produce photographic image capture. The source of images is, or can be referenced via a {{MediaStreamTrack}}.
 Previous Version: https://www.w3.org/TR/2017/WD-image-capture-20170104/
 
-!Participate: <a href="https://lists.w3.org/Archives/Public/public-media-capture/">Mailing list</a>
+!Participate: <a href="https://lists.w3.org/Archives/Public/public-webrtc/">Mailing list</a>
 !Participate: <a href="https://github.com/w3c/mediacapture-image">GitHub repo</a> (<a href="https://github.com/w3c/mediacapture-image/issues/new">new issue</a>, <a href="https://github.com/w3c/mediacapture-image/issues">open issues</a>)
 
 !Implementation: <a href="https://github.com/w3c/mediacapture-image/blob/master/implementation-status.md">Implementation Status</a>


### PR DESCRIPTION
The mailing list "public-media-capture" is not active anymore and has
been effectively replaced by public-webrtc. This change updates the
information on the spec.