### PR TITLE
Update python version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.7"
 install:
   - pip install pygments lxml setuptools --upgrade
   - git clone https://github.com/tabatkins/bikeshed.git


### PR DESCRIPTION
According to https://travis-ci.com/github/w3c/mediacapture-image/builds/154272334, `bikeshed requires Python '>=3.7' but the running Python is 2.7.15`. This PR updates python version in Travis from 2.7 to 3.7.

![image](https://user-images.githubusercontent.com/634478/77294204-1e01d000-6ce4-11ea-9fc8-9036a5205434.png)


