### PR TITLE
Define when gUM rejects with required PTZ constraints

### DIFF
--- a/ptz-explainer.md
+++ b/ptz-explainer.md
@@ -106,6 +106,19 @@ if ("tilt" in capabilities) {
 }
 ```
 
+The example below shows how camera pan could be reset when acquiring a
+PTZ camera in `getUserMedia()`.
+
+```js
+// User is prompted to grant both camera and PTZ access in a single call.
+// If the camera does not support PTZ or user denies PTZ permission, it fails
+// as PTZ constraints are required.
+const videoStream = await navigator.mediaDevices.getUserMedia({
+  // [NEW] Website asks to reset camera pan.
+  video: { pan: 1 },
+});
+```
+
 [Spec PR](https://github.com/w3c/mediacapture-image/pull/218)
 
 ## Integration with the Permissions API

--- a/ptz-explainer.md
+++ b/ptz-explainer.md
@@ -41,9 +41,12 @@ track capabilities, constraints and settings. These new constraints apply to the
 live video feed. Those will also be used in `getUserMedia()` to express whether a
 website wants to control camera PTZ functionality. In other words, it will be
 used to request the PTZ permission, a separate permission, in a single
-`getUserMedia()` call, along the camera permission. If the selected/connected
-camera does not support PTZ though or user blocks solely the PTZ permission, the
-UA may fall back to the camera permission.
+`getUserMedia()` call, along the camera permission.
+
+If the selected/connected camera does not support PTZ though or user blocks solely
+the PTZ permission, the UA will either reject the `getUserMedia()` call if PTZ
+constraints are required, or fall back to the camera permission if PTZ constraints
+are defined as advanced constraints.
 
 The [new "true" semantics] for `pan`, `tilt`, and `zoom` makes it possible to
 acquire a PTZ camera in `getUserMedia()` without altering the current pan, tilt
@@ -61,13 +64,17 @@ to the user.
 ```js
 // User is prompted to grant both camera and PTZ access in a single call.
 // If the camera does not support PTZ or user denies PTZ permission, it falls
-// back to a "regular" camera prompt.
+// back to a "regular" camera prompt as PTZ constraints are defined as advanced
+// constraints.
 const videoStream = await navigator.mediaDevices.getUserMedia({
   video: {
-    // [NEW] Website asks to control camera PTZ as well.
-    pan: true, tilt: true, zoom: true,
-  }
+    advanced: [{
+      // [NEW] Website asks to control camera PTZ as well.
+      pan: true, tilt: true, zoom: true,
+    }],
+  },
 });
+
 
 // Show camera video stream to user.
 const video = document.querySelector("video");

--- a/ptz-explainer.md
+++ b/ptz-explainer.md
@@ -75,7 +75,6 @@ const videoStream = await navigator.mediaDevices.getUserMedia({
   },
 });
 
-
 // Show camera video stream to user.
 const video = document.querySelector("video");
 video.srcObject = videoStream;


### PR DESCRIPTION
As discussed with @guidou, we should make it clear how `getUserMedia()` can reject when PTZ constraints are required.

This currently means `getUserMedia({video: {pan: 1}})` for instance rejects with an `OverConstrainedError`. We should think about how to make sure we don't leak camera PTZ capabilities when user didn't grant access yet.

@reillyeon @eehakkin @riju @andypaicu