### PR TITLE
Add toJSON() for MediaSettingsRange

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -280,6 +280,7 @@ interface ImageCapture {
       readonly attribute double max;
       readonly attribute double min;
       readonly attribute double step;
+      [Default] object toJSON();
   };
 </pre>
 
@@ -294,6 +295,13 @@ interface ImageCapture {
 
   <dt><dfn attribute for="MediaSettingsRange"><code>step</code></dfn></dt>
   <dd>The minimum difference between consecutive values of this setting.</dd>
+</dl>
+
+## Methods ## {#mediasettingsrange-methods}
+
+<dl class="domintro">
+  <dt><dfn method for="MediaSettingsRange"><code>toJSON()</code></dfn></dt>
+  <dd>When called, run [[!WEBIDL]]'s <a>default toJSON steps</a>.</dd>
 </dl>
 
 # {{RedEyeReduction}} # {#redeyereduction-section}


### PR DESCRIPTION
This PR simply adds a default toJSON() to MediaSettingsRange so that web developers simply interesting in logging capabilities can do so with `JSON.stringify(myTrack.getCapabilities())`.

It was done for MediaDeviceInfo previously. See https://w3c.github.io/mediacapture-main/#dom-mediadeviceinfo-tojson