### PR TITLE
Fix build warnings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,6 +2,7 @@
 Title: MediaStream Image Capture
 Repository: image-capture
 Group: mediacapture
+Markup Shorthands: markdown yes
 Status: ED
 ED: https://w3c.github.io/mediacapture-image/
 TR: https://www.w3.org/TR/image-capture/
@@ -199,7 +200,7 @@ interface ImageCapture {
     <li>Let <var>p</var> be a new promise.</li>
     <li>Run the following steps in parallel:
     <ol>
-      <li>Gather data from {{track}} into an {{ImageBitmap}} object. The |width| and |height| of the {{ImageBitmap}} object are derived from the constraints of {{track}}.
+      <li>Gather data from {{track}} into an {{ImageBitmap}} object. The {{ImageBitmap/width}} and {{ImageBitmap/height}} of the {{ImageBitmap}} object are derived from the constraints of {{track}}.
       </li>
 
       <li>If the operation cannot be completed for any reason (for example, upon invocation of multiple {{grabFrame()}}/{{takePhoto()}} method calls in rapid succession), then reject <var>p</var> with</a> a new {{DOMException}} whose name is {{UnknownError}}, and abort these steps.</li>
@@ -738,11 +739,11 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
     <li><i><dfn>Exposure</dfn></i> is the amount of light that is allowed to fall on the photosensitive device. In auto-exposure modes ({{MeteringMode/single-shot}} or {{MeteringMode/continuous}} {{MediaTrackSettings/exposureMode}}), the exposure time and/or camera aperture are automatically adjusted by the implementation based on the subject of the photo. In {{MeteringMode/manual}} {{MediaTrackSettings/exposureMode}}, these parameters are set to fixed absolute values.</li>
 
-    <li><dfn>Focus mode</dfn> describes the focus setting of the capture device (e.g. |auto| or |manual|). </li>
+    <li><dfn>Focus mode</dfn> describes the focus setting of the capture device (e.g. `auto` or `manual`). </li>
 
     <li><dfn>Points of interest</dfn> describe the metering area centers used in other settings, e.g. <a>exposure</a>, <a>white balance mode</a> and <a>focus mode</a> each one being a {{Point2D}} (usually these three controls are modified simultaneously by the so-called <code>3A</code> algorithm: auto-focus, auto-exposure, auto-white-balance).
 
-    A {{Point2D}} Point of Interest is interpreted to represent a pixel position in a normalized square space (|{x,y} &isin; [0.0, 1.0]|). The origin of coordinates |{x,y} = {0.0, 0.0}| represents the upper leftmost corner whereas the |{x,y} = {1.0, 1.0}| represents the lower rightmost corner: the <a href="#dom-point2d-x"><code>x</code></a> coordinate (columns) increases rightwards and the <a href="#dom-point2d-y"><code>y</code></a> coordinate (rows) increases downwards. Values beyond the mentioned limits will be clamped to the closest allowed value.</li>
+    A {{Point2D}} Point of Interest is interpreted to represent a pixel position in a normalized square space (`{x,y} &isin; [0.0, 1.0]`). The origin of coordinates `{x,y} = {0.0, 0.0}` represents the upper leftmost corner whereas the `{x,y} = {1.0, 1.0}` represents the lower rightmost corner: the <a href="#dom-point2d-x"><code>x</code></a> coordinate (columns) increases rightwards and the <a href="#dom-point2d-y"><code>y</code></a> coordinate (rows) increases downwards. Values beyond the mentioned limits will be clamped to the closest allowed value.</li>
 
     <li><i><dfn>Exposure Compensation</dfn></i> is a numeric camera setting that adjusts the exposure level from the current value used by the implementation.  This value can be used to bias the exposure level enabled by auto-exposure, and usually is a symmetric range around 0 EV (the no-compensation value). This value is only used in {{MeteringMode/single-shot}} and {{MeteringMode/continuous}} {{MediaTrackSettings/exposureMode}}.</li>
 
@@ -759,7 +760,7 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
     <li>[[LIGHTING-VOCABULARY]] defines <i><dfn>saturation</dfn></i> as "the colourfulness of an area judged in proportion to its brightness" and in the current context it refers to a numeric camera setting that controls the intensity of color in a scene (i.e. the amount of gray in the scene). Very low saturation levels will result in photos closer to black-and-white. Saturation is similar to <a>contrast</a> but referring to colors, so its implementation, albeit being platform dependent, can be understood as a gain factor applied to the chroma components of a given image.</li>
 
-    <li><i><dfn>Sharpness</dfn></i> is a numeric camera setting that controls the intensity of edges in a scene.  Higher sharpness settings result in higher contrast along the edges, while lower settings result in less contrast and blurrier edges (i.e. soft focus). The implementation is platform dependent, but it can be understood as the linear combination of an edge detection operation applied on the original image and the original image itself; the relative weights being cotrolled by this |sharpness|.
+    <li><i><dfn>Sharpness</dfn></i> is a numeric camera setting that controls the intensity of edges in a scene.  Higher sharpness settings result in higher contrast along the edges, while lower settings result in less contrast and blurrier edges (i.e. soft focus). The implementation is platform dependent, but it can be understood as the linear combination of an edge detection operation applied on the original image and the original image itself; the relative weights being controlled by this <a>sharpness</a>.
 
     <div class="note">
       <a>Brightness</a>, <a>contrast</a>, <a>saturation</a> and <a>sharpness</a> are specified in [[UVC]].
@@ -804,7 +805,7 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
     If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/zoom}} dictionary member exists after a possible normalization.
 
 
-    <li><dfn>Fill light mode</dfn> describes the flash setting of the capture device (e.g. |auto|, |off|, |on|). <dfn>Torch</dfn> describes the setting of the source's fill light as  continuously connected, staying on as long as {{track}} is active.</li>
+    <li><dfn>Fill light mode</dfn> describes the flash setting of the capture device (e.g. `auto`, `off`, `on`). <dfn>Torch</dfn> describes the setting of the source's fill light as  continuously connected, staying on as long as {{track}} is active.</li>
   </ol>
 
 # {{MeteringMode}} # {#meteringmode-section}


### PR DESCRIPTION
This PR fixes build warnings below raised by bikeshed:

```
WARNING: The following <var>s were only used once in the document:
  'width'
  'height'
  'manual'
  'sharpness'
  'off'
  'on'
If these are not typos, please add an ignore='' attribute to the <var>.
```