### PR TITLE
Clarify pan/tilt/zoom capabilities and settings (#245)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -493,7 +493,10 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>This reflects the supported range of <a>contrast</a>. Values are numeric.  Increasing values indicate increasing contrast.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>pan</code></dfn></dt>
-  <dd>This reflects the <a>pan</a> value range supported by the UA.</dd>
+  <dd>This reflects the <a>pan</a> value range supported by the UA and by the track.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>pan</a>.
+  In that case the UA MUST NOT expose the <a>pan</a> value range.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>saturation</code></dfn></dt>
   <dd>This reflects the permitted range of <a>saturation</a> setting. Values are numeric. Increasing values indicate increasing saturation.</dd>
@@ -505,10 +508,16 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>This reflects the <a>focus distance</a> value range supported by the UA.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>tilt</code></dfn></dt>
-  <dd>This reflects the <a>tilt</a> value range supported by the UA.</dd>
+  <dd>This reflects the <a>tilt</a> value range supported by the UA and by the track.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>tilt</a>.
+  In that case the UA MUST NOT expose the <a>tilt</a> value range.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>zoom</code></dfn></dt>
-  <dd>This reflects the <a>zoom</a> value range supported by the UA.</dd>
+  <dd>This reflects the <a>zoom</a> value range supported by the UA by the track.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>zoom</a>.
+  In that case the UA MUST NOT expose the <a>zoom</a> value range.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>torch</code></dfn></dt>
   <dd>A boolean indicating whether camera supports <a>torch</a>  mode- on meaning supported.</dd>
@@ -673,7 +682,10 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
   <dd>This reflects the current <a>contrast</a> setting of the camera.</dd>
 
   <dt><dfn dict-member for="MediaTrackSettings"><code>pan</code></dfn></dt>
-  <dd>This reflects the current <a>pan</a> setting of the camera.</dd>
+  <dd>This reflects the current <a>pan</a> setting of the camera.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>pan</a>.
+  In that case the UA MUST NOT expose the <a>pan</a> setting.</dd>
 
   <dt><dfn dict-member for="MediaTrackSettings"><code>saturation</code></dfn></dt>
   <dd>This reflects the current <a>saturation</a> setting of the camera.</dd>
@@ -685,10 +697,16 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
   <dd>This reflects the current <a>focus distance</a> setting of the camera.</dd>
 
   <dt><dfn dict-member for="MediaTrackSettings"><code>tilt</code></dfn></dt>
-  <dd>This reflects the current <a>tilt</a> setting of the camera.</dd>
+  <dd>This reflects the current <a>tilt</a> setting of the camera.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>tilt</a>.
+  In that case the UA MUST NOT expose the <a>tilt</a> setting.</dd>
 
   <dt><dfn dict-member for="MediaTrackSettings"><code>zoom</code></dfn></dt>
-  <dd>This reflects the current <a>zoom</a> setting of the camera.</dd>
+  <dd>This reflects the current <a>zoom</a> setting of the camera.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>zoom</a>.
+  In that case the UA MUST NOT expose the <a>zoom</a> setting.</dd>
 
   <dt><dfn dict-member for="MediaTrackSettings"><code>torch</code></dfn></dt>
   <dd>Current camera <a>torch</a> configuration setting.</dd>


### PR DESCRIPTION
This CL mandates PTZ capabilities and settings must be sanitized based on permission.
I hope that this clarifies the issue.