### PR TITLE
Clarify pan/tilt/zoom capabilities (#245)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -493,7 +493,15 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>This reflects the supported range of <a>contrast</a>. Values are numeric.  Increasing values indicate increasing contrast.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>pan</code></dfn></dt>
-  <dd>This reflects the <a>pan</a> value range supported by the UA.</dd>
+  <dd>This reflects the <a>pan</a> value range supported by the UA and by the track.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>pan</a>.
+  In that case the UA MUST NOT expose the <a>pan</a> value range.
+
+  <div class="note">
+    It does not matter whether the algorithm to <a>request permission to use</a> a PermissionDescriptor returns the current permission state without user interaction (when the current state is not "prompt") or asks the user's permission.
+    In both cases, the permission to use is requested and either granted or denied.
+  </div></dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>saturation</code></dfn></dt>
   <dd>This reflects the permitted range of <a>saturation</a> setting. Values are numeric. Increasing values indicate increasing saturation.</dd>
@@ -505,10 +513,16 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>This reflects the <a>focus distance</a> value range supported by the UA.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>tilt</code></dfn></dt>
-  <dd>This reflects the <a>tilt</a> value range supported by the UA.</dd>
+  <dd>This reflects the <a>tilt</a> value range supported by the UA and by the track.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>tilt</a>.
+  In that case the UA MUST NOT expose the <a>tilt</a> value range.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>zoom</code></dfn></dt>
-  <dd>This reflects the <a>zoom</a> value range supported by the UA.</dd>
+  <dd>This reflects the <a>zoom</a> value range supported by the UA and by the track.
+
+  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>zoom</a>.
+  In that case the UA MUST NOT expose the <a>zoom</a> value range.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>torch</code></dfn></dt>
   <dd>A boolean indicating whether camera supports <a>torch</a>  mode- on meaning supported.</dd>


### PR DESCRIPTION
Split from https://github.com/w3c/mediacapture-image/pull/248 per @youennf's request.