### PR TITLE
Allow only ideal PTZ constraints in gUM

### DIFF
--- a/ptz-explainer.md
+++ b/ptz-explainer.md
@@ -107,7 +107,7 @@ to reject with `OverConstrainedError`.
 ```js
 const videoStream = await navigator.mediaDevices.getUserMedia({
   // [NEW] Website asks to reset camera pan.
-  video: { pan: 1 },
+  video: { pan: 0 },
 });
 ```
 


### PR DESCRIPTION
This PR updates the PTZ explainer with the resolution "05" at https://www.w3.org/2020/09/15-webrtc-minutes.html#r05
I believe @eehakkin will follow with spec changes.

@jan-ivar @youennf @riju 