### PR TITLE
Allow PTZ support to be always exposed in capabilities

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -493,10 +493,16 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>This reflects the supported range of <a>contrast</a>. Values are numeric.  Increasing values indicate increasing contrast.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>pan</code></dfn></dt>
-  <dd>This reflects the <a>pan</a> value range supported by the UA and by the track.
+  <dd>
+    This reflects the <a>pan</a> value range supported by the UA and by the track.
 
-  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>pan</a>.
-  In that case the UA MUST NOT expose the <a>pan</a> value range.</dd>
+    If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>pan</a>.
+    In that case the UA MUST NOT expose the <a>pan</a> value range but MAY provide an empty {{MediaSettingsRange}} dictionary to indicate that the underlying video source supports <a>pan</a>.
+
+    <div class="note">
+      Even if the UA provides an empty {{MediaSettingsRange}} dictionary to indicate that the underlying video source supports <a>pan</a>, <a>tilt</a> or <a>zoom</a>, that support can be utilized only after a new {{getUserMedia()}} call which resolves with a {{MediaStream}} object which contains a video track which supports <a>pan</a>, <a>tilt</a> or <a>zoom</a>.
+    </div>
+  </dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>saturation</code></dfn></dt>
   <dd>This reflects the permitted range of <a>saturation</a> setting. Values are numeric. Increasing values indicate increasing saturation.</dd>
@@ -508,16 +514,20 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>This reflects the <a>focus distance</a> value range supported by the UA.</dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>tilt</code></dfn></dt>
-  <dd>This reflects the <a>tilt</a> value range supported by the UA and by the track.
+  <dd>
+    This reflects the <a>tilt</a> value range supported by the UA and by the track.
 
-  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>tilt</a>.
-  In that case the UA MUST NOT expose the <a>tilt</a> value range.</dd>
+    If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>tilt</a>.
+    In that case the UA MUST NOT expose the <a>tilt</a> value range but MAY provide an empty {{MediaSettingsRange}} dictionary to indicate that the underlying video source supports <a>tilt</a>.
+  </dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>zoom</code></dfn></dt>
-  <dd>This reflects the <a>zoom</a> value range supported by the UA and by the track.
+  <dd>
+    This reflects the <a>zoom</a> value range supported by the UA and by the track.
 
-  If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>zoom</a>.
-  In that case the UA MUST NOT expose the <a>zoom</a> value range.</dd>
+    If the track has been created without <a>requesting permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true or if that permission request is denied, the track does not support <a>zoom</a>.
+    In that case the UA MUST NOT expose the <a>zoom</a> value range but MAY provide an empty {{MediaSettingsRange}} dictionary to indicate that the underlying video source supports <a>zoom</a>.
+  </dd>
 
   <dt><dfn dict-member for="MediaTrackCapabilities"><code>torch</code></dfn></dt>
   <dd>A boolean indicating whether camera supports <a>torch</a>  mode- on meaning supported.</dd>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-image/issues/245. This is to address https://www.w3.org/2020/09/15-webrtc-minutes.html#r06


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eehakkin/intel-w3c-mediacapture-image/pull/260.html" title="Last updated on Feb 15, 2021, 7:19 AM UTC (3006eb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-image/260/72ee760...eehakkin:3006eb1.html" title="Last updated on Feb 15, 2021, 7:19 AM UTC (3006eb1)">Diff</a>