### PR TITLE
Replace PTZ boolean normalization with boolean constraints

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -591,9 +591,7 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>See <a>contrast</a> constrainable property.</dd>
 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>pan</code></dfn></dt>
-  <dd>A value of true is normalized to a value of empty {{ConstrainDoubleRange}}.
-      A value of false is normalized to a value of undefined.
-      See <a>pan</a> constrainable property.</dd>
+  <dd>See <a>pan</a> constrainable property.</dd>
 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>saturation</code></dfn></dt>
   <dd>See <a>saturation</a> constrainable property.</dd>
@@ -605,14 +603,10 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
   <dd>See <a>focus distance</a> constrainable property.</dd>
 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>tilt</code></dfn></dt>
-  <dd>A value of true is normalized to a value of empty {{ConstrainDoubleRange}}.
-      A value of false is normalized to a value of undefined.
-      See <a>tilt</a> constrainable property.</dd>
+  <dd>See <a>tilt</a> constrainable property.</dd>
 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>zoom</code></dfn></dt>
-  <dd>A value of true is normalized to a value of empty {{ConstrainDoubleRange}}.
-      A value of false is normalized to a value of undefined.
-      See <a>zoom</a> constrainable property.</dd>
+  <dd>See <a>zoom</a> constrainable property.</dd>
 
   <dt><dfn dict-member for="MediaTrackConstraintSet"><code>torch</code></dfn></dt>
   <dd>See <a>torch</a> constrainable property.</dd>
@@ -795,22 +789,19 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
     <li><dfn>Pan</dfn> is a numeric camera setting that controls the pan of the camera. The setting represents pan in arc seconds, which are 1/3600th of a degree. Values are in the range from -180\*3600 arc seconds to +180\*3600 arc seconds. Positive values pan the camera clockwise as viewed from above, and negative values pan the camera counter clockwise as viewed from above.
 
-    Any algorithm which uses a {{MediaTrackConstraintSet}} object and its {{MediaTrackConstraintSet/pan}} dictionary member which exists after a possible normalization MUST <a>request permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId.
+    Constraints on pan influence camera selection through <a>fitness distance</a> toward cameras with the ability to pan. To exert this influence without overwriting the current pan setting, pan may be constrained to true. Conversely, constraining it to false disfavors cameras with the ability to pan.
 
-    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/pan}} dictionary member exists after a possible normalization.
+    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/pan}} dictionary member exists with a value other than false MUST either <a>request permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the pan setting.
 
-    <div class="note">
-      The {{MediaTrackConstraintSet/pan}}, {{MediaTrackConstraintSet/tilt}} and {{MediaTrackConstraintSet/zoom}} dictionary members exists after a possible normalization if the normalized value is a double value or a {{ConstrainDoubleRange}} value (whether empty or not).
-      A boolean value of true is normalized to an empty {{ConstrainDoubleRange}} value thus the dictionary member exists after a normalization.
-      A boolean value of false is normalized to no value thus the dictionary member does not exist after a normalization.
-      An empty {{ConstrainDoubleRange}} value implies no constraints but only a permission and capability request.
-    </div></li>
+    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/pan}} dictionary member exists with a value other than false.</li>
 
     <li><dfn>Tilt</dfn> is a numeric camera setting that controls the tilt of the camera. The setting represents tilt in arc seconds, which are 1/3600th of a degree. Values are in the range from -180\*3600 arc seconds to +180\*3600 arc seconds. Positive values tilt the camera upward when viewed from the front, and negative values tilt the camera downward as viewed from the front.
 
-    Any algorithm which uses a {{MediaTrackConstraintSet}} object and its {{MediaTrackConstraintSet/tilt}} dictionary member which exists after a possible normalization MUST <a>request permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId.
+    Constraints on tilt influence camera selection through <a>fitness distance</a> toward cameras with the ability to tilt. To exert this influence without overwriting the current tilt setting, tilt may be constrained to true. Conversely, constraining it to false disfavors cameras with the ability to tilt.
 
-    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/tilt}} dictionary member exists after a possible normalization.
+    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/tilt}} dictionary member exists with a value other than false MUST either <a>request permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the tilt setting.
+
+    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/tilt}} dictionary member exists with a value other than false.
 
     <div class="note">
       There is no defined order when applying <a>pan</a> and <a>tilt</a>, the UA is allowed to apply them in any order. In practice this should not matter since these values are absolute, so order will not affect the final position. However, if applying pan and tilt is slow enough, the order in which they are applied may be visually noticeable.
@@ -818,10 +809,11 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
     <li><dfn>Zoom</dfn> is a numeric camera setting that controls the focal length of the lens. The setting usually represents a ratio, e.g. 4 is a zoom ratio of 4:1. The minimum value is usually 1, to represent a 1:1 ratio (i.e. no zoom).
 
-    Any algorithm which uses a {{MediaTrackConstraintSet}} object and its {{MediaTrackConstraintSet/zoom}} dictionary member which exists after a possible normalization MUST <a>request permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId.
+    Constraints on zoom influence camera selection through <a>fitness distance</a> toward cameras with the ability to zoom. To exert this influence without overwriting the current zoom setting, zoom may be constrained to true. Conversely, constraining it to false disfavors cameras with the ability to zoom.
 
-    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/zoom}} dictionary member exists after a possible normalization.
+    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/zoom}} dictionary member exists with a value other than false MUST either <a>request permission to use</a> (as defined in [[!permissions]]) a PermissionDescriptor with its name member set to {{PermissionName/camera}} and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the zoom setting.
 
+    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/zoom}} dictionary member exists with a value other than false.</li>
 
     <li><dfn>Fill light mode</dfn> describes the flash setting of the capture device (e.g. `auto`, `off`, `on`). <dfn>Torch</dfn> describes the setting of the source's fill light as  continuously connected, staying on as long as {{track}} is active.</li>
   </ol>
@@ -1178,8 +1170,11 @@ urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dictionary; text:
 
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dictionary; text: MediaTrackSettings; url: idl-def-MediaTrackSettings
 
-
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: constrainable property; url: defining-a-new-constrainable-property
+
+urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: fitness distance; url: dfn-fitness-distance
+
+urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: settings dictionary; url: dfn-settings-dictionary
 
 urlPrefix: https://www.w3.org/TR/page-visibility/; type: attribute; text: visibilityState; for: Document; url: dom-visibilitystate
 </pre>


### PR DESCRIPTION
Fixes #256. This along with https://github.com/w3c/mediacapture-main/pull/742 is to clarify meaning of PTZ constraints presence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eehakkin/intel-w3c-mediacapture-image/pull/271.html" title="Last updated on Mar 16, 2021, 2:40 PM UTC (3bef8ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-image/271/72ee760...eehakkin:3bef8ed.html" title="Last updated on Mar 16, 2021, 2:40 PM UTC (3bef8ed)">Diff</a>