### PR TITLE
Fix mixed up definitions of imageWidth and imageHeight

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -263,11 +263,11 @@ interface ImageCapture {
   <dt><dfn dict-member for="PhotoSettings"><code>redEyeReduction</code></dfn></dt>
   <dd>This reflects whether camera <a>red eye reduction</a> is desired</dd>
 
-  <dt><dfn dict-member for="PhotoSettings"><code>imageWidth</code></dfn></dt>
-  <dd>This reflects the desired <a>image height</a>.  The UA MUST select the closest height value this setting if it supports a discrete set of height options.</dd>
-
   <dt><dfn dict-member for="PhotoSettings"><code>imageHeight</code></dfn></dt>
-  <dd>This reflects the desired <a>image width</a>. The UA MUST select the closest width value this setting if it supports a discrete set of width options.</dd>
+  <dd>This reflects the desired <a>image height</a>.  The UA MUST select the closest height value to this setting if it supports a discrete set of height options.</dd>
+
+  <dt><dfn dict-member for="PhotoSettings"><code>imageWidth</code></dfn></dt>
+  <dd>This reflects the desired <a>image width</a>. The UA MUST select the closest width value to this setting if it supports a discrete set of width options.</dd>
 
   <dt><dfn dict-member for="PhotoSettings"><code>fillLightMode</code></dfn></dt>
   <dd>This reflects the desired <a>fill light mode</a> (flash) setting.</dd>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-image/pull/274.html" title="Last updated on Feb 9, 2021, 10:04 AM UTC (88937d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-image/274/7a1e01d...88937d0.html" title="Last updated on Feb 9, 2021, 10:04 AM UTC (88937d0)">Diff</a>