### PR TITLE
Drop most explicit anchors from Bikeshed settings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -101,7 +101,7 @@ interface ImageCapture {
         <td class="prmType">{{MediaStreamTrack}}</td>
         <td class="prmNullFalse"><span role="img" aria-label="False">&#10008;</span></td>
         <td class="prmOptFalse"><span role="img" aria-label="False">&#10008;</span></td>
-        <td class="prmDesc">The {{MediaStreamTrack}} to be used as source of data. This will be the value of the {{track}} attribute. The {{MediaStreamTrack}} passed to the constructor MUST have its {{kind}} attribute set to <code>"video"</code> otherwise a {{DOMException}} of type {{NotSupportedError}} will be thrown.</td>
+        <td class="prmDesc">The {{MediaStreamTrack}} to be used as source of data. This will be the value of the {{track}} attribute. The {{MediaStreamTrack}} passed to the constructor MUST have its {{MediaStreamTrack/kind}} attribute set to <code>"video"</code> otherwise a {{DOMException}} of type {{NotSupportedError}} will be thrown.</td>
       </tr>
     </tbody>
   </table>
@@ -111,7 +111,7 @@ interface ImageCapture {
   <dd>
   {{takePhoto()}} produces the result of a single photographic exposure using the video capture device sourcing the {{track}} and including any {{PhotoSettings}} configured, returning an encoded image in the form of a {{Blob}} if successful. When this method is invoked, the user agent MUST run the following steps:
   <ol>
-    <li>If the {{readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps. </li>
+    <li>If the {{MediaStreamTrack/readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps. </li>
     <li>Let <var>p</var> be a new promise.</li>
     <li>Run the following steps in parallel:
     <ol>
@@ -155,7 +155,7 @@ interface ImageCapture {
   <dd>
   {{getPhotoCapabilities()}} is used to retrieve the ranges of available configuration options, if any. When this method is invoked, the user agent MUST run the following steps:
   <ol>
-    <li>If the {{readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps. </li>
+    <li>If the {{MediaStreamTrack/readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps. </li>
 
     <li>Let <var>p</var> be a new promise.</li>
     <li>Run the following steps in parallel:
@@ -175,7 +175,7 @@ interface ImageCapture {
   <dd>
   {{getPhotoSettings()}} is used to retrieve the current configuration settings values, if any. When this method is invoked, the user agent MUST run the following steps:
   <ol>
-    <li>If the {{readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps. </li>
+    <li>If the {{MediaStreamTrack/readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps. </li>
 
     <li>Let <var>p</var> be a new promise.</li>
     <li>Run the following steps in parallel:
@@ -194,7 +194,7 @@ interface ImageCapture {
   <dt><dfn method for="ImageCapture"><code>grabFrame()</code></dfn></dt>
   <dd>{{grabFrame()}} takes a snapshot of the live video being held in {{track}}, returning an {{ImageBitmap}} if successful. {{grabFrame()}} returns data only once upon being invoked. When this method is invoked, the user agent MUST run the following steps:
   <ol>
-    <li>If the {{readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps.</li>
+    <li>If the {{MediaStreamTrack/readyState}} of {{track}} provided in the constructor is not {{live}}, return <a>a promise rejected with</a> a new {{DOMException}} whose name is {{InvalidStateError}}, and abort these steps.</li>
 
     <li>Let <var>p</var> be a new promise.</li>
     <li>Run the following steps in parallel:
@@ -347,7 +347,7 @@ interface ImageCapture {
 
 # Extensions # {#extensions}
 
-This Section defines a number of new set of <a>Constrainable Properties</a> for {{MediaStreamTrack}} that can be applied in order to make its behavior more suitable for taking pictures.  Use of these constraints via {{MediaStreamTrack}}'s methods {{getCapabilities()}}, {{getSettings()}}, {{getConstraints()}} and {{applyConstraints()}} will modify the behavior of  the {{ImageCapture}} object's {{track}}.
+This Section defines a new set of [[mediacapture-streams#constrainable-properties|constrainable properties]] for {{MediaStreamTrack}} that can be applied in order to make its behavior more suitable for taking pictures.  Use of these constraints via {{MediaStreamTrack}}'s methods {{MediaStreamTrack/getCapabilities()}}, {{MediaStreamTrack/getSettings()}}, {{MediaStreamTrack/getConstraints()}} and {{MediaStreamTrack/applyConstraints()}} will modify the behavior of  the {{ImageCapture}} object's {{track}}.
 
 ## {{MediaTrackSupportedConstraints}} dictionary ## {#mediatracksupportedconstraints-section}
 
@@ -434,7 +434,7 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
 
 ## {{MediaTrackCapabilities}} dictionary ## {#mediatrackcapabilities-section}
 
-{{MediaTrackCapabilities}} is extended here with the capabilities specific to image capture. This dictionary is produced by the UA via {{getCapabilities()}} and represents the supported ranges and enumerations of the supported constraints.
+{{MediaTrackCapabilities}} is extended here with the capabilities specific to image capture. This dictionary is produced by the UA via {{MediaStreamTrack/getCapabilities()}} and represents the supported ranges and enumerations of the supported constraints.
 
 <pre class="idl">
   partial dictionary MediaTrackCapabilities {
@@ -499,7 +499,7 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
     In that case the UA MUST NOT expose the <a>pan</a> value range but MAY provide an empty {{MediaSettingsRange}} dictionary to indicate that the underlying video source supports <a>pan</a>.
 
     <div class="note">
-      Even if the UA provides an empty {{MediaSettingsRange}} dictionary to indicate that the underlying video source supports <a>pan</a>, <a>tilt</a> or <a>zoom</a>, that support can be utilized only after a new {{getUserMedia()}} call which resolves with a {{MediaStream}} object which contains a video track which supports <a>pan</a>, <a>tilt</a> or <a>zoom</a>.
+      Even if the UA provides an empty {{MediaSettingsRange}} dictionary to indicate that the underlying video source supports <a>pan</a>, <a>tilt</a> or <a>zoom</a>, that support can be utilized only after a new {{MediaDevices/getUserMedia()}} call which resolves with a {{MediaStream}} object which contains a video track which supports <a>pan</a>, <a>tilt</a> or <a>zoom</a>.
     </div>
   </dd>
 
@@ -534,7 +534,7 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
 
 ## {{MediaTrackConstraintSet}} dictionary ## {#mediatrackconstraintset-section}
 
-{{MediaTrackConstraintSet}} [[!GETUSERMEDIA]] dictionary is used for both reading the current status with {{getConstraints()}} and for applying a set of constraints with {{applyConstraints()}}.
+{{MediaTrackConstraintSet}} [[!GETUSERMEDIA]] dictionary is used for both reading the current status with {{MediaStreamTrack/getConstraints()}} and for applying a set of constraints with {{MediaStreamTrack/applyConstraints()}}.
 
 <div class="note">
 {{MediaTrackSettings}} can be retrieved to verify the effect of the application by the user agent of the requested {{MediaTrackConstraints}}. Some constraints such as, e.g. <a>zoom</a>, might not be immediately applicable.
@@ -623,7 +623,7 @@ This Section defines a number of new set of <a>Constrainable Properties</a> for 
 
 ## {{MediaTrackSettings}} dictionary ## {#mediatracksettings-section}
 
-When the {{getSettings()}} method is invoked on a video stream track, the user agent must return the extended {{MediaTrackSettings}} dictionary, representing the current status of the underlying user agent.
+When the {{MediaStreamTrack/getSettings()}} method is invoked on a video stream track, the user agent must return the extended {{MediaTrackSettings}} dictionary, representing the current status of the underlying user agent.
 
 <pre class="idl">
   partial dictionary MediaTrackSettings {
@@ -749,7 +749,7 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
   <div class="note">
     None of the names of these photo capabilities and constrainable properties are in the list of <a>allowed required constraints for device selection</a>.
-    Therefore, in <a>getUserMedia()</a>, these photo capabilities and constrainable properties can be constrained only with <a>optional basic constraints</a> and <a>advanced constraints</a>, but not with <a>required constraints</a>.
+    Therefore, in {{MediaDevices/getUserMedia()}}, these photo capabilities and constrainable properties can be constrained only with <a>optional basic constraints</a> and <a>advanced constraints</a>, but not with <a>required constraints</a>.
   </div>
 
   <ol>
@@ -808,17 +808,17 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
     Constraints on pan influence camera selection through <a>fitness distance</a> toward cameras with the ability to pan. To exert this influence without overwriting the current pan setting, pan may be constrained to true. Conversely, constraining it to false disfavors cameras with the ability to pan.
 
-    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/pan}} dictionary member exists with a value other than false MUST either <a>request permission to use</a> (as defined in [[!permissions]]) a {{PermissionDescriptor}} with its name member set to <a permission>camera</a> and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the pan setting.
+    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/pan}} dictionary member exists with a value other than false MUST either [=request permission to use=] (as defined in [[!permissions]]) a {{PermissionDescriptor}} with its name member set to <a permission>camera</a> and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the pan setting.
 
-    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/pan}} dictionary member exists with a value other than false.</li>
+    If the {{Document/visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{MediaStreamTrack/applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/pan}} dictionary member exists with a value other than false.</li>
 
     <li><dfn>Tilt</dfn> is a numeric camera setting that controls the tilt of the camera. The setting represents tilt in arc seconds, which are 1/3600th of a degree. Values are in the range from -180\*3600 arc seconds to +180\*3600 arc seconds. Positive values tilt the camera upward when viewed from the front, and negative values tilt the camera downward as viewed from the front.
 
     Constraints on tilt influence camera selection through <a>fitness distance</a> toward cameras with the ability to tilt. To exert this influence without overwriting the current tilt setting, tilt may be constrained to true. Conversely, constraining it to false disfavors cameras with the ability to tilt.
 
-    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/tilt}} dictionary member exists with a value other than false MUST either <a>request permission to use</a> (as defined in [[!permissions]]) a {{PermissionDescriptor}} with its name member set to <a permission>camera</a> and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the tilt setting.
+    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/tilt}} dictionary member exists with a value other than false MUST either [=request permission to use=] (as defined in [[!permissions]]) a {{PermissionDescriptor}} with its name member set to <a permission>camera</a> and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the tilt setting.
 
-    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/tilt}} dictionary member exists with a value other than false.
+    If the {{Document/visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{MediaStreamTrack/applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/tilt}} dictionary member exists with a value other than false.
 
     <div class="note">
       There is no defined order when applying <a>pan</a> and <a>tilt</a>, the UA is allowed to apply them in any order. In practice this should not matter since these values are absolute, so order will not affect the final position. However, if applying pan and tilt is slow enough, the order in which they are applied may be visually noticeable.
@@ -828,9 +828,9 @@ When the {{getSettings()}} method is invoked on a video stream track, the user a
 
     Constraints on zoom influence camera selection through <a>fitness distance</a> toward cameras with the ability to zoom. To exert this influence without overwriting the current zoom setting, zoom may be constrained to true. Conversely, constraining it to false disfavors cameras with the ability to zoom.
 
-    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/zoom}} dictionary member exists with a value other than false MUST either <a>request permission to use</a> (as defined in [[!permissions]]) a {{PermissionDescriptor}} with its name member set to <a permission>camera</a> and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the zoom setting.
+    Any algorithm which uses a {{MediaTrackConstraintSet}} object whose {{MediaTrackConstraintSet/zoom}} dictionary member exists with a value other than false MUST either [=request permission to use=] (as defined in [[!permissions]]) a {{PermissionDescriptor}} with its name member set to <a permission>camera</a> and its {{CameraDevicePermissionDescriptor/panTiltZoom}} member set to true, and, optionally, consider its {{DevicePermissionDescriptor/deviceId}} member set to any appropriate device's deviceId, or decide not to expose the zoom setting.
 
-    If the {{visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/zoom}} dictionary member exists with a value other than false.</li>
+    If the {{Document/visibilityState}} of the <a>top-level browsing context</a> value is "hidden", the {{MediaStreamTrack/applyConstraints()}} algorithm MUST throw a {{SecurityError}} if {{MediaTrackConstraintSet/zoom}} dictionary member exists with a value other than false.</li>
 
     <li><dfn>Fill light mode</dfn> describes the flash setting of the capture device (e.g. `auto`, `off`, `on`). <dfn>Torch</dfn> describes the setting of the source's fill light as  continuously connected, staying on as long as {{track}} is active.</li>
   </ol>
@@ -1145,50 +1145,6 @@ A {{Point2D}} represents a location in a two dimensional space. The origin of co
 
 
 <pre class="anchors">
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: interface; text: MediaStreamTrack; url: mediastreamtrack
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: onmute; url: widl-MediaStreamTrack-onmute
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: onunmute; url: widl-MediaStreamTrack-onunmute
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: attribute; text: readyState; url: widl-MediaStreamTrack-readyState
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: attribute; text: kind; url: widl-MediaStreamTrack-kind
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: enum-value; text: live; url: idl-def-MediaStreamTrackState.live
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: getUserMedia(); url: dom-mediadevices-getusermedia
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: getSettings(); url: widl-ConstrainablePattern-getSettings-Settings
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: getCapabilities(); url: widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: getConstraints(); url: widl-MediaStreamTrack-getConstraints-MediaTrackConstraints
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: applyConstraints(); url: dom-mediastreamtrack-applyconstraints
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: interface; text: MediaDevices; url: mediadevices-interface-extensions
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: method; text: getSupportedConstraints(); url: widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: interface; text: ConstrainDouble ; url: idl-def-constraindouble
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: interface; text: ConstrainDOMString ; url: idl-def-constraindomstring
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: interface; text: ConstrainBoolean ; url: idl-def-ConstrainBoolean
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dictionary; text: MediaTrackSupportedConstraints; url: idl-def-MediaTrackSupportedConstraints
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dictionary; text: MediaTrackCapabilities; url: idl-def-MediaTrackCapabilities
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dictionary; text: MediaTrackConstraintSet; url: idl-def-MediaTrackConstraintSet
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dictionary; text: MediaTrackConstraints; url: idl-def-MediaTrackConstraints
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dictionary; text: MediaTrackSettings; url: idl-def-MediaTrackSettings
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: constrainable property; url: defining-a-new-constrainable-property
-
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: advanced constraints; url: dfn-advanced-constraints
 
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: allowed required constraints for device selection; url: dfn-allowed-required-constraints-for-device-selection
@@ -1196,21 +1152,10 @@ urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: allowe
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: optional basic constraints; url: dfn-optional-basic-constraints
 
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: required constraints; url: dfn-required-constraints
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: fitness distance; url: dfn-fitness-distance
-
-urlPrefix: https://www.w3.org/TR/mediacapture-streams/#; type: dfn; text: settings dictionary; url: dfn-settings-dictionary
-
-urlPrefix: https://www.w3.org/TR/page-visibility/; type: attribute; text: visibilityState; for: Document; url: dom-visibilitystate
 </pre>
 
 <pre class="link-defaults">
-spec: html
-    type: dfn
-        text: allowed to show a popup
-        text: in parallel
-        text: incumbent settings object
-spec:webidl; type:interface; text:Promise
+spec: html; type: attribute; text: visibilityState
 </pre>
 
 <pre class="biblio">


### PR DESCRIPTION
The anchors are no longer needed now that Bikeshed's xref database contains the definitions from Media Capture and Streams, and some of the underlying URLs are outdated.

The few explicit anchors that remain link to definitions that are not (yet?) exported by Media Capture and Streams.

(Note the remaining "link-default" is because Bikeshed still has Page Visibility in its database. That spec was merged into HTML, so reference should now go to HTML)

This should fix #295.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/mediacapture-image/pull/297.html" title="Last updated on Dec 7, 2022, 6:59 PM UTC (28fab85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-image/297/6c99181...tidoust:28fab85.html" title="Last updated on Dec 7, 2022, 6:59 PM UTC (28fab85)">Diff</a>