### PR TITLE
Update Image Capture polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Specification and Samples
 * [Image Capture (a.k.a. MediaStream Image Capture) Specification](https://w3c.github.io/mediacapture-image/), including code samples.
 * [Implementation Status](implementation-status.md) describes various browser support on platforms, hardware compatibility, etc.
 * [Sample code](https://rawgit.com/Miguelao/demos/master/imagecapture.html)
-* [Image Capture polyfill](https://github.com/dandv/imagecapture)
+* [Image Capture polyfill](https://github.com/GoogleChromeLabs/imagecapture-polyfill)
 
 Notes on bikeshedding :bicyclist:
 --------------

--- a/index.bs
+++ b/index.bs
@@ -19,6 +19,8 @@ Abstract: This document specifies methods and camera settings to produce photogr
 !Implementation: <a href="https://github.com/w3c/mediacapture-image/blob/master/implementation-status.md">Implementation Status</a>
 !Implementation: <a href="http://caniuse.com/#feat=imagecapture">Can I use Image Capture?</a>
 
+!Polyfills: <a href="https://github.com/GoogleChromeLabs/imagecapture-polyfill">GoogleChromeLabs/imagecapture-polyfill</a>
+
 </pre>
 
 <style>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 20, 2023, 3:03 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FFluorescentHallucinogen%2Fmediacapture-image%2F3cbf00cde13f698dc069fafc450b477367cfad37%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/mediacapture-image%23299.)._
</details>
