### PR TITLE
Fix auto-publish workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,10 +1,12 @@
 name: Auto-publish
 on:
   pull_request: {}
-  workflow_dispatch:
-  paths: index.bs
   push:
-    branches: [main]
+    branches:
+      - main
+    paths:
+      - index.bs
+  workflow_dispatch:
 
 jobs:
   main:


### PR DESCRIPTION
The `paths:` is not a trigger but a restriction for the `push:` trigger.